### PR TITLE
Use ufw for NAT

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -32,3 +32,5 @@ galaxy_info:
 dependencies:
   - src: https://github.com/cisagov/ansible-role-pip
     name: pip
+  - src: https://github.com/cisagov/ansible-role-ufw
+    name: ufw

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,8 @@ galaxy_info:
   author: Mark Feldhousen
   description: OpenVPN Ansible role
   company: CISA Cyber Assessments
+  galaxy_tags:
+    - openvpn
   license: CC0
   min_ansible_version: 2.0
   platforms:
@@ -26,8 +28,7 @@ galaxy_info:
       versions:
         - bionic
         - xenial
-  galaxy_tags:
-    - openvpn
+  role_name: openvpn
 
 dependencies:
   - src: https://github.com/cisagov/ansible-role-pip

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -31,3 +31,14 @@
 
 - name: Import python playbook
   import_playbook: python.yml
+
+# Some of our Debian Docker images (9 and 10) are missing netbase,
+# which provides /etc/services.  This is the file that ufw uses to map
+# port names (e.g. "openvpn") to port numbers, and so we require it.
+- name: Install netbase (Debian)
+  hosts: os_Debian
+  tasks:
+    - name: Install netbase (Debian)
+      package:
+        name:
+          - netbase

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -5,5 +5,7 @@
   name: python
 - src: https://github.com/cisagov/ansible-role-remove-python2
   name: remove_python2
+- src: https://github.com/cisagov/ansible-role-ufw
+  name: ufw
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade

--- a/tasks/enable_nat.yml
+++ b/tasks/enable_nat.yml
@@ -1,30 +1,14 @@
 ---
-# tasks file for enabling NAT and iptables persistence
-
-- name: Install sysctl
-  package:
-    name: "{{ sysctl_package_names }}"
+- name: Set default forward policy to "ACCEPT" for ufw
+  lineinfile:
+    dest: /etc/default/ufw
+    regexp: ^DEFAULT_FORWARD_POLICY=
+    state: present
+    line: DEFAULT_FORWARD_POLICY="ACCEPT"
 
 - name: Enable NAT sysctl value for IPv4 NAT
-  sysctl:
-    name: net.ipv4.ip_forward
-    value: '1'
-    sysctl_set: yes
-    # sysctl_file: "/etc/sysctl.conf"
-
-- name: Install packages for iptables persistence
-  package:
-    name: "{{ iptables_persistence_package_names }}"
-
-# Unless you do this, systemd can sometimes get confused when you try
-# to start a service you just installed
-- name: Systemd daemon-reload
-  systemd:
-    daemon_reload: true
-  when:
-    - ansible_service_mgr == "systemd"
-
-- name: Enable service for iptables persistence
-  service:
-    name: "{{ iptables_persistence_service_name }}"
-    enabled: yes
+  lineinfile:
+    dest: /etc/ufw/sysctl.conf
+    regexp: ^#net/ipv4/ip_forward=1
+    state: present
+    line: net/ipv4/ip_forward=1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,3 +72,10 @@
 
 - name: Load tasks file for enabling NAT
   include: enable_nat.yml
+
+- name: Configure ufw to allow OpenVPN via UDP
+  ufw:
+    comment: Allow OpenVPN via UDP
+    proto: udp
+    rule: allow
+    to_port: openvpn


### PR DESCRIPTION
## 🗣 Description

This pull request modifies the Ansible role to install [`ufw`](https://wiki.ubuntu.com/UncomplicatedFirewall) and set up NATing via the `ufw` configuration instead of directly using `iptables`.

## 💭 Motivation and Context

We previously set up NATing using `iptables` directly.  Now that we are required to harden the OpenVPN AMI, it ends up with `ufw` installed.  As a result, it makes more sense now to set up the NAT via `ufw`, so that all the firewall configuration is consolidated and `ufw` and the `iptables-restore` toolchain don't clobber each other.

Tangentially related to cisagov/openvpn-packer#24.

See also cisagov/openvpn-server-tf-module#40.

## 🧪 Testing

These changes have been used to deploy a working OpenVPN AMI to our staging COOL environment.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
