### PR TITLE
Cease setting the default forward policy to accept

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@
 
 Ansible role for installing and configuring an
 [OpenVPN](https://openvpn.net) server.  This role also enables IPv4
-NAT via [ufw](https://wiki.ubuntu.com/UncomplicatedFirewall).
+NAT via [ufw](https://wiki.ubuntu.com/UncomplicatedFirewall), although
+_it does not set the default policy for routed packets in UFW, nor
+does it create any rules to allow them through._  This is because
+there is no way to know a priori whether the user wants to deny all
+routed packets and create rules to allow them through or just default
+allow all routed packets; therefore, you must manage this part of the
+ufw configuration outside of this Ansible role.
 
 Note that this role cannot perform every step necessary to set up NAT.
 Once an instance is started up, one must determine the NAT interface

--- a/tasks/enable_nat.yml
+++ b/tasks/enable_nat.yml
@@ -1,11 +1,4 @@
 ---
-- name: Set default forward policy to "ACCEPT" for ufw
-  lineinfile:
-    dest: /etc/default/ufw
-    regexp: ^DEFAULT_FORWARD_POLICY=
-    state: present
-    line: DEFAULT_FORWARD_POLICY="ACCEPT"
-
 - name: Enable NAT sysctl value for IPv4 NAT
   lineinfile:
     dest: /etc/ufw/sysctl.conf


### PR DESCRIPTION
## 🗣 Description

This pull request:
* Ceases setting the default forwarded/routed policy to `ALLOW` (or anything else)
* Updates `README.md` to let the user know that he or she will need to configure the forwarded/routed traffic via ufw outside of this role.

## 💭 Motivation and Context

For hardened systems the user may well want the default policy for forwarded/routed traffic to be `DENY` and create a rule to allow specific forwarded/routed traffic through.

See also cisagov/openvpn-packer@172e6600c667f1d17525ca8990a257d7473464a7.

## 🧪 Testing

I have successfully built a COOL OpenVPN AMI with these changes and verified that they work as intended.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
