### PR TITLE
Support older DOE PIV certificates

### DIFF
--- a/files/fetch_user_ca_certs.sh
+++ b/files/fetch_user_ca_certs.sh
@@ -12,6 +12,9 @@ URLS=(
   # Department of Energy
   "https://enrollwebfed.managed.entrust.com/fssp/cda-docs/certs/EntrustRoot_to_EntrustSSP_2018_08_13.cer"
   "https://enrollwebfed.managed.entrust.com/fssp/cda-docs/certs/FedRootCA2019.cer"
+  # Support older DOE PIVs (issued prior to Aug. 2019)
+  "http://rootweb.managed.entrust.com/AIA/CertsIssuedToEMSRootCA.p7c"
+  "http://sspweb.managed.entrust.com/AIA/CertsIssuedToEMSSSPCA.p7c"
   # Department of Homeland Security
   "https://pki.treas.gov/dhsca_fullpath.p7b"
 )

--- a/files/fetch_user_ca_certs.sh
+++ b/files/fetch_user_ca_certs.sh
@@ -35,7 +35,7 @@ fetch() {
       # Certificate is already in PEM format.
       cp "${source_file}" cert-a
     fi
-  elif [[ $url =~ .p7b$ ]]; then
+  elif [[ $url =~ .p7[bc]$ ]]; then
     # Download the certificate bundle and massage into correct format.
     curl --insecure --silent "${url}" \
       | openssl pkcs7 -print_certs -inform der -out "${source_file}"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds older CA certificates that are required to verify older Department of Energy PIV certificates.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We are working with some users who have older (early 2019) DOE PIVs and their certificates could not be verified until we added the appropriate CA certificates to our trust store.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This change was validated in Staging by running the updated `fetch_user_ca_certs.sh` to pull in the new CA certificates and hash them for use for OpenVPN.  Then (_and this part is quite important_), the VPN service was restarted so that the new CA certificates were picked up and used.  After that, our intrepid DOE PIV user was able to successfully connect to our VPN.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
