### PR TITLE
Prefer unit file drop-ins to editing the unit file provided by the package manager

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,6 +1,7 @@
 """Module containing the tests for the default scenario."""
 
 # Standard Python Libraries
+import configparser
 import os
 
 # Third-Party Libraries
@@ -17,3 +18,20 @@ def test_sysctl_settings(host, setting):
     """Test that sysctl values were set properly."""
     for key in setting:
         assert setting[key] == host.sysctl(key)
+
+
+@pytest.mark.parametrize(
+    "section,option,value",
+    [
+        ("Unit", "After", "network.target multi-user.target cloud-final.service"),
+        ("Service", "PrivateTmp", "False"),
+    ],
+)
+def test_openvpn_unit_modifications(host, section, option, value):
+    """Test that OpenVPN unit has been modified as expected."""
+    cmd = host.run("systemctl cat openvpn-server@primary.service")
+    assert cmd.rc == 0
+    config = configparser.ConfigParser(strict=False)
+    config.read_string(cmd.stdout)
+    assert config[section][option]
+    assert config[section][option] == value

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -20,18 +20,36 @@ def test_sysctl_settings(host, setting):
         assert setting[key] == host.sysctl(key)
 
 
+# The "type" string must correspond to a get*(section, option,...)
+# method of the ConfigParser class.  Options for the "type" string
+# are:
+# - "", which results in a call to get() and returns a string value
+# - "boolean" which results in a call to getboolean() and returns a
+#   Boolean value
+# - "int" which results in a call to getint() and returns an integer
+#   value
+# - "float" which results in a call to getfloat() and returns a
+#   floating-point value
+#
+# See here for more details:
+# https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.get
 @pytest.mark.parametrize(
-    "section,option,value",
+    "section,option,value,value_type",
     [
-        ("Unit", "After", "network.target multi-user.target cloud-final.service"),
-        ("Service", "PrivateTmp", "False"),
+        ("Unit", "After", "network.target multi-user.target cloud-final.service", ""),
+        ("Service", "PrivateTmp", False, "boolean"),
     ],
 )
-def test_openvpn_unit_modifications(host, section, option, value):
+def test_openvpn_unit_modifications(host, section, option, value, value_type):
     """Test that OpenVPN unit has been modified as expected."""
     cmd = host.run("systemctl cat openvpn-server@primary.service")
     assert cmd.rc == 0
     config = configparser.ConfigParser(strict=False)
     config.read_string(cmd.stdout)
-    assert config[section][option]
-    assert config[section][option] == value
+
+    # Now we dynamically construct the method of ConfigParser that we
+    # want to call depending on the value of "type".
+    method_name = f"get{value_type}"
+    assert hasattr(config, method_name)
+    assert callable(method := getattr(config, method_name))
+    assert method(section, option) == value

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,19 +37,46 @@
     chdir: /etc/openvpn/server
     creates: /etc/openvpn/server/certs
 
+- name: >-
+    Ensure that the directory where the OpenVPN unit drop-in will live
+    actually exists
+  ansible.builtin.file:
+    group: root
+    mode: 0755
+    owner: root
+    path: /etc/systemd/system/{{ openvpn_service_name }}@.service.d
+    state: directory
+
 - name: Configure OpenVPN service to run after multi-user and cloud-final
-  ansible.builtin.lineinfile:
-    dest: /lib/systemd/system/{{ openvpn_service_name }}@.service
-    line: After=network.target multi-user.target cloud-final.service
-    regexp: ^After=
-    state: present
+  community.general.ini_file:
+    group: root
+    mode: 0644
+    # This is just to maintain the look and feel of the
+    # /usr/lib/systemd/system/openvpn-server@.service file as provided
+    # by the package manager.
+    no_extra_spaces: true
+    option: After
+    owner: root
+    path: >-
+      /etc/systemd/system/{{ openvpn_service_name
+      }}@.service.d/99-start-after-multi-user-and-cloud-final.conf
+    section: Unit
+    value: network.target multi-user.target cloud-final.service
 
 - name: Disable OpenVPN private tmp directory to allow certificate file sharing
-  ansible.builtin.lineinfile:
-    dest: /lib/systemd/system/{{ openvpn_service_name }}@.service
-    line: PrivateTmp=false
-    regexp: ^PrivateTmp=
-    state: present
+  community.general.ini_file:
+    group: root
+    mode: 0644
+    # This is just to maintain the look and feel of the
+    # /lib/systemd/system/openvpn-server@.service file as provided by
+    # the package manager.
+    no_extra_spaces: true
+    option: PrivateTmp
+    owner: root
+    path: >-
+      /etc/systemd/system/{{ openvpn_service_name }}@.service.d/99-no-private-tmp.conf
+    section: Service
+    value: false
 
 - name: Enable OpenVPN
   ansible.builtin.systemd_service:


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the role to use drop-ins to alter the behavior of the `systemd` unit file, as opposed to editing the unit file provided by the package manager.

## 💭 Motivation and context ##

This pull request resolves #80.  Using a unit file drop-in is [the preferred method for making alterations to units](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Examples).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.